### PR TITLE
modify currency updater class_eval, fixes #1

### DIFF
--- a/app/models/spree/order/currency_updater_decorator.rb
+++ b/app/models/spree/order/currency_updater_decorator.rb
@@ -1,33 +1,31 @@
 module Spree
-  class Order < Spree::Base
-    CurrencyUpdater.class_eval do
+  Order::CurrencyUpdater.class_eval do
 
-      # Returns the price object from given item
-      def list_price_from_line_item(line_item)
-        line_item.variant.list_price_in(currency, store_id, user.try(:price_book_role_ids))
-      end
-
-      # Returns the price object from given item
-      def price_from_line_item(line_item)
-        line_item.variant.price_in(currency, store_id, user.try(:price_book_role_ids))
-      end
-
-      # Updates price from given line item
-      def update_line_item_price!(line_item)
-        list_price = list_price_from_line_item(line_item)
-        price = price_from_line_item(line_item)
-
-        if price
-          line_item.update_attributes!(
-            currency: price.currency,
-            list_price: list_price.price,
-            price: price.price
-          )
-        else
-          raise RuntimeError, "no #{currency} price found for #{line_item.product.name} (#{line_item.variant.sku})"
-        end
-      end
-
+    # Returns the price object from given item
+    def list_price_from_line_item(line_item)
+      line_item.variant.list_price_in(currency, store_id, user.try(:price_book_role_ids))
     end
+
+    # Returns the price object from given item
+    def price_from_line_item(line_item)
+      line_item.variant.price_in(currency, store_id, user.try(:price_book_role_ids))
+    end
+
+    # Updates price from given line item
+    def update_line_item_price!(line_item)
+      list_price = list_price_from_line_item(line_item)
+      price = price_from_line_item(line_item)
+
+      if price
+        line_item.update_attributes!(
+          currency: price.currency,
+          list_price: list_price.price,
+          price: price.price
+        )
+      else
+        raise RuntimeError, "no #{currency} price found for #{line_item.product.name} (#{line_item.variant.sku})"
+      end
+    end
+
   end
 end


### PR DESCRIPTION
this little change on `class_eval` syntax fixes some strange class loading problems on my `2-4-stable`, like:

`TypeError (superclass mismatch for class Order):
  ruby (2.2.0) bundler/gems/spree-6aa500c4cade/core/app/models/spree/order/currency_updater.rb:2:in `<module:Spree>'` 

good for all branches.
