### PR TITLE
Add supported currencies

### DIFF
--- a/app/models/spree/store_decorator.rb
+++ b/app/models/spree/store_decorator.rb
@@ -7,4 +7,8 @@ Spree::Store.class_eval do
 
   has_many :store_price_books
 
+  def supported_currencies
+    price_books.pluck(:currency).uniq
+  end
+
 end

--- a/spec/models/spree/store_spec.rb
+++ b/spec/models/spree/store_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Spree::Store do
+  let(:price_books) do
+    [
+      create(:price_book, currency: 'AUD'),
+      create(:price_book, currency: 'USD'),
+      create(:price_book, currency: 'DKK')
+    ]
+  end
+  let(:store) { create(:store, price_books: price_books) }
+
+  context 'supported currencies' do
+    example 'finds all currencies from the stores price books' do
+      expect(store.supported_currencies).to eq ['AUD', 'USD', 'DKK']
+    end
+  end
+end


### PR DESCRIPTION
A simple method for quickly grabbing supported currencies from a store, similar idea to the config options for supported_currencies but per store.
