### PR TITLE
3-1-stable with money-open-exchange-rates

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,16 @@ bundle exec rails g spree_price_books:install
 Configuration
 -------------
 
-Once installed you can seed default currency exchange rates via Google's Currency API.
+Once installed you can seed default currency exchange rates via open exchange rate
+
+Get your app id from https://openexchangerates.org/signup
+
+Add open_exchange_rate.rb to config/initializers
+```ruby
+Rails.application.config.openExchangeRate = {
+  appId: 'YOUR APP ID HERE',
+}
+```
 
 ```shell
 bundle exec rake price_books:currency_rates

--- a/app/assets/javascripts/spree/frontend/spree_price_books.js
+++ b/app/assets/javascripts/spree/frontend/spree_price_books.js
@@ -1,4 +1,3 @@
 // Placeholder manifest file.
 // the installer will append this file to the app vendored assets here: vendor/assets/javascripts/spree/frontend/all.js'
 //= require spree/frontend
-//= require spree/frontend/spree_multi_currency

--- a/app/overrides/spree/admin/shared/_product_sub_menu/add_price_books_tab.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_product_sub_menu/add_price_books_tab.html.erb.deface
@@ -1,4 +1,0 @@
-<!--
-insert_bottom "[data-hook='admin_product_sub_tabs'], #sub_nav"
--->
-<%= tab :price_books %>

--- a/app/overrides/spree/admin/shared/_product_tabs/add_price_books.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_product_tabs/add_price_books.html.erb.deface
@@ -1,5 +1,5 @@
 <!-- insert_bottom "[data-hook='admin_product_tabs']" -->
 
 <li<%== ' class="active"' if current == "Prices" %>>
-  <%= link_to_with_icon 'icon-picture', Spree::PriceBook.model_name.human(:count => 2), spree.variant_prices_admin_product_url(@product) %>
+  <%= link_to_with_icon 'list', Spree::PriceBook.model_name.human(:count => 2), spree.variant_prices_admin_product_url(@product) %>
 </li>

--- a/app/overrides/spree/admin/shared/sub_menu/_configuration/current_rates_link.html.erb.deface
+++ b/app/overrides/spree/admin/shared/sub_menu/_configuration/current_rates_link.html.erb.deface
@@ -1,5 +1,5 @@
 <!-- insert_bottom "[data-hook='admin_configurations_sidebar_menu'], #admin_configurations_sidebar_menu[data-hook]" -->
 
 <% if can? :manage, Spree::CurrencyRate %>
-  <%= configurations_sidebar_menu_item Spree.t(:currency_rates), spree.admin_currency_rates_path %>
+  <%= configurations_sidebar_menu_item Spree::CurrencyRate.model_name.human(count: 1.1), spree.admin_currency_rates_path %>
 <% end %>

--- a/app/overrides/spree/admin/shared/sub_menu/_product/add_price_books_tab.html.erb.deface
+++ b/app/overrides/spree/admin/shared/sub_menu/_product/add_price_books_tab.html.erb.deface
@@ -1,0 +1,4 @@
+<!--
+insert_bottom "[data-hook='admin_product_sub_tabs'], #sub_nav"
+-->
+<%= tab :price_books, label: Spree::PriceBook.model_name.human(count: 1.1) %>

--- a/app/views/spree/admin/currency_rates/_form.html.erb
+++ b/app/views/spree/admin/currency_rates/_form.html.erb
@@ -6,16 +6,17 @@
       <div class="alpha six columns">
         <div data-hook="base_currency" class="field">
           <%= f.label :base_currency %>
-          <%= f.text_field :base_currency, class: 'fullwidth' %>
+          <%= f.text_field :base_currency, class: 'form-control' %>
         </div>
         <div data-hook="currency" class="field">
           <%= f.label :currency, Spree.t(:currency) %>
-          <%= f.text_field :currency, class: 'fullwidth' %>
+          <%= f.text_field :currency, class: 'form-control' %>
         </div>
         <div data-hook="exchange_rate" class="field">
-          <%= f.label :exchange_rate, Spree.t(:exchange_rate) %>
-          <%= f.text_field :exchange_rate, :class => 'fullwidth' %>
-          <br/><span class="info"><%= Spree.t(:currency_rate_explanation) %></span>
+          <%= f.label :exchange_rate %>
+          <%= f.text_field :exchange_rate, :class => 'form-control' %>
+          <br/>
+          <!--<span class="info"><%= Spree.t(:currency_rate_explanation) %></span>-->
         </div>
         <% if f.object.default? || Spree::CurrencyRate.default.new_record? %>
           <div data-hook="default_rate" class="field">

--- a/app/views/spree/admin/currency_rates/edit.html.erb
+++ b/app/views/spree/admin/currency_rates/edit.html.erb
@@ -1,13 +1,10 @@
-<%= render 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:editing_currency_rate) %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li>
     <%= button_link_to Spree.t(:back_to_currency_rates_list), spree.admin_currency_rates_path, icon: 'arrow-left' %>
-  </li>
 <% end %>
 
 <%= render partial: 'spree/shared/error_messages', locals: { target: @currency_rate } %>

--- a/app/views/spree/admin/currency_rates/index.html.erb
+++ b/app/views/spree/admin/currency_rates/index.html.erb
@@ -1,19 +1,16 @@
-<%= render 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:currency_rates) %>
+  <%= Spree::CurrencyRate.model_name.human(:count => 2) %>
 <% end %>
 
 <% content_for :page_actions do %>
   <% if can? :create, Spree::CurrencyRate %>
-    <li>
       <%= button_link_to Spree.t(:new_currency_rate), new_object_url, icon: 'plus' %>
-    </li>
     <% end %>
 <% end %>
 
 <% if @currency_rates.any? %>
-  <table class="index">
+  <table class="table">
     <colgroup>
       <col style="width: 25%">
       <col style="width: 25%">
@@ -23,10 +20,10 @@
     </colgroup>
     <thead>
       <tr data-hook="rate_header">
-        <th><%= Spree.t(:base_currency) %></th>
-        <th><%= Spree.t(:exchange_rate) %></th>
-        <th><%= Spree.t(:currency) %></th>
-        <th><%= Spree.t(:default) %></th>
+        <th><%= Spree::CurrencyRate.human_attribute_name(:base_currency) %></th>
+        <th><%= Spree::CurrencyRate.human_attribute_name(:exchange_rate) %></th>
+        <th><%= Spree::CurrencyRate.human_attribute_name(:currency) %></th>
+        <th><%= Spree::CurrencyRate.human_attribute_name(:default) %></th>
         <th class="actions"></th>
       </tr>
     </thead>

--- a/app/views/spree/admin/currency_rates/new.html.erb
+++ b/app/views/spree/admin/currency_rates/new.html.erb
@@ -1,4 +1,3 @@
-<%= render 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:new_currency_rate) %>

--- a/app/views/spree/admin/price_books/_form.html.erb
+++ b/app/views/spree/admin/price_books/_form.html.erb
@@ -1,79 +1,79 @@
 <div data-hook="admin_price_book_form_fields">
 
   <div class="row">
-    <div class="alpha eight columns">
+    <div class="col-md-6">
       <%= f.field_container :name do %>
         <%= f.label :name %> <span class="required">*</span><br />
-        <%= f.text_field :name, class: "fullwidth" %>
+        <%= f.text_field :name, class: "form-control" %>
         <%= f.error_message_on :name %>
       <% end %>
     </div>
+  </div>
 
-    <div class="omega eight columns">
-      <div class="field">
+    <div class="row">
+      <div class="col-md-6">
         <%= f.label :currency, Spree.t(:choose_currency) %> <span class="required">*</span><br />
-        <%= f.select :currency, pb_currency_options(f.object.currency), class: 'fullwidth select2' %>
+        <%= f.select :currency, pb_currency_options(f.object.currency), class: 'form-control select2' %>
         <%= f.error_message_on :currency %>
       </div>
     </div>
-  </div>
 
   <div class="row">
-    <div class="alpha four columns">
+    <div class="col-md-6">
       <%= f.field_container :active_from do %>
         <%= f.label :active_from %> <span class="required">*</span><br />
-        <%= f.text_field :active_from, class: 'datepicker datepicker-from' %>
+        <%= f.text_field :active_from, class: 'form-control datepicker datepicker-from' %>
         <%= f.error_message_on :active_from %>
       <% end %>
     </div>
 
-    <div class="four columns">
+    <div class="col-md-6">
       <%= f.field_container :active_to do %>
         <%= f.label :active_to %> <span class="required">*</span><br />
-        <%= f.text_field :active_to, class: 'datepicker datepicker-to' %>
+        <%= f.text_field :active_to, class: 'form-control datepicker datepicker-to' %>
         <%= f.error_message_on :active_to %>
       <% end %>
     </div>
 
-    <div class="four columns">
+    <div class="col-md-6">
       <%= f.field_container :role_id do %>
         <%= f.label :role_id %><br />
-        <%= f.collection_select :role_id, Spree::Role.all, :id, :name, { include_blank: true }, { class: 'fullwidth select2' } %>
+        <%= f.collection_select :role_id, Spree::Role.all, :id, :name, { include_blank: true }, { class: 'select2' } %>
         <%= f.error_message_on :role_id %>
       <% end %>
     </div>
 
-    <div class="omega four columns">
+    <div class="col-md-6">
       <%= f.field_container :priority do %>
         <%= f.label :priority %> <span class="required">*</span><br />
-        <%= f.text_field :priority, class: "fullwidth" %>
+        <%= f.text_field :priority, class: "form-control" %>
         <%= f.error_message_on :priority %>
       <% end %>
     </div>
   </div>
 
   <div class="row">
-    <div class="alpha four columns">
+    <div class="col-md-12">
       <%= f.field_container :parent do %>
-        <%= f.label :parent, Spree.t(:parent) %> <span class="required">*</span><br />
+        <%= f.label :parent %> <span class="required">*</span><br />
         <%= f.collection_select(:parent_id, Spree::PriceBook.all - [f.object], :id, :name,
-              include_blank: true, selected: Spree::PriceBook.default.id, class: 'fullwidth select2') %>
+              include_blank: true, selected: Spree::PriceBook.default.id, class: 'select2') %>
         <%= f.error_message_on :parent %>
       <% end %>
     </div>
-    <div class="four columns">
+    <div class="col-md-12">
       <%= f.field_container :price_adjustment_factor do %>
         <%= f.label :price_adjustment_factor %> <span class="required">*</span><br />
-        <%= f.text_field :price_adjustment_factor, class: 'fullwidth' %>
+        <%= f.text_field :price_adjustment_factor, class: 'form-control' %>
         <%= f.error_message_on :price_adjustment_factor %>
       <% end %>
     </div>
 
-    <div class="omega four columns">
+    <div class="col-md-12">
       <%= f.field_container :discount do %>
         <%= f.label :discount %><br />
         <%= f.check_box :discount %>
-        <%= f.error_message_on :priority %>
+        <%= f.error_message_on :discount %>
       <% end %>
     </div>
 

--- a/app/views/spree/admin/price_books/edit.html.erb
+++ b/app/views/spree/admin/price_books/edit.html.erb
@@ -1,13 +1,11 @@
-<%= render :partial => 'spree/admin/shared/product_sub_menu' %>
+<%#= render :partial => 'spree/admin/shared/product_sub_menu' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:editing_price_book) %> <span class="green">"<%= @price_book.name %>"</span>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li>
-    <%= button_link_to Spree.t(:back_to_price_books_list), spree.admin_price_books_path, :icon => 'icon-arrow-left' %>
-  </li>
+  <%= button_link_to Spree.t(:back_to_price_books_list), spree.admin_price_books_path, :icon => 'icon-arrow-left' %>
 <% end %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @price_book } %>

--- a/app/views/spree/admin/price_books/index.html.erb
+++ b/app/views/spree/admin/price_books/index.html.erb
@@ -3,17 +3,15 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <li id="new_pb_link">
-    <%= button_link_to Spree.t(:new_price_book), new_admin_price_book_url, { :remote => true, :icon => 'icon-plus', :id => 'new_price_book_link' } %>
-  </li>
+    <%= link_to_with_icon 'add', Spree.t(:new_price_book), new_admin_price_book_url, { :remote => true, :class => 'btn btn-success', :id => 'new_price_book_link' } %>
 <% end %>
 
-<%= render :partial => 'spree/admin/shared/product_sub_menu' %>
+<%#= render :partial => 'spree/admin/shared/product_sub_menu' %>
 
 <div id="price_book_form_wrapper"></div>
 
 <% if @price_books.any? %>
-<table class="index sortable" id="listing_price_bookss" data-hook data-sortable-link="<%= update_positions_admin_option_types_url %>">
+<table class="table sortable" id="listing_price_bookss" data-hook data-sortable-link="<%= update_positions_admin_option_types_url %>">
   <colgroup>
     <col style="width: 5%">
     <col style="width: 30%">

--- a/app/views/spree/admin/price_books/new.html.erb
+++ b/app/views/spree/admin/price_books/new.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/product_sub_menu' %>
+<%#= render :partial => 'spree/admin/shared/product_sub_menu' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:new_price_book) %>

--- a/app/views/spree/admin/products/variant_prices.html.erb
+++ b/app/views/spree/admin/products/variant_prices.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/product_sub_menu' %>
+<%#= render :partial => 'spree/admin/shared/product_sub_menu' %>
 <%= render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => 'Prices' } %>
 
 <%# did we get her via redirect? %>
@@ -12,7 +12,7 @@
     <%= select_tag :price_book_id, options_for_select(@price_books.map {|pb| ["#{pb.name} (#{pb.currency})", pb.id]}, @current_price_book.id) %>
   </div>
 
-  <table class="index">
+  <table class="table">
     <colgroup>
       <col style="width: 70%" />
       <col style="width: 15%" />
@@ -29,7 +29,7 @@
     <% @variants.each do |variant| %>
       <tr id="<%= spree_dom_id variant %>" <%= 'style="color:red;"' if variant.deleted? %> data-hook="variants_row" class="<%= cycle('odd', 'even')%>">
         <td><%= variant.is_master? ? 'Master' : variant.options_text %></td>
-        <td class="align-center"><%= Spree::Money.new(variant.default_price.amount, currency: variant.default_price.currency) %></td>
+        <td class="align-center"><%= Spree::Money.new(variant.default_price.try(:amount), currency: variant.default_price.try(:currency)) %></td>
         <td class="align-center">
           <% if @current_price_book.factored? %>
             <%= Spree::Money.new(@prices[variant.id].amount, currency: @prices[variant.id].currency) %>
@@ -52,9 +52,7 @@
     <span class="or"><%= Spree.t(:or) %></span>
     <%= button_link_to Spree.t('actions.cancel'), spree.admin_product_url(@product), :icon => 'icon-remove' %>
   </div>
-  
+
   <%# this is horrible Jeff S.  Why didn't you just keep the product in the route? %>
   <%= hidden_field_tag :product_id, @product.id %> <%# due to the goofy way i chose to do my routing/redirecting %>
 </form>
-
-

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,6 +12,7 @@ en:
       spree/price_book:
         currency: Currency
         default: Default
+        priority: Priority
         price_adjustment_factor: Factor
     errors:
       models:
@@ -27,4 +28,8 @@ en:
         one: Price Book
         other: Price Books
   spree:
+    default_price: Default price
+    new_price_book: New Price Book
+    back_to_price_books_list: Back to price books
     editing_currency_rate: Editing Currency Rate
+    editing_price_book: Editing Price Book

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1,0 +1,44 @@
+ru:
+  activerecord:
+    attributes:
+      spree/currency_rate:
+        base_currency: Базовая Валюта
+        currency: Валюта
+        default: По умолчанию
+        exchange_rate: Курс обмена
+      spree/price_book:
+        name: Название
+        active_from: Активно с
+        active_to: Активно до
+        currency: Валюта
+        default: По умолчанию
+        priority: Приоритет
+        role: Роль
+        discount: Скидка?
+        parent: Родительское ценовое правило
+        price_adjustment_factor: Коэффициент корректировки цены
+    errors:
+      models:
+        spree/price:
+          attributes:
+            currency:
+              match_price_book: Must match price book currency.
+    models:
+      spree/currency_rate:
+        one: Курс обмена
+        few: Курсы обмена
+        many: Курсы обмена
+        other: Курсы обмена
+      spree/price_book:
+        one: Ценовое правило
+        few: Ценовые правила
+        many: Ценовые правила
+        other: Ценовые правила
+  spree:
+    new_currency_rate: Новый курс обмена
+    default_price: Цена по умолчанию
+    new_price_book: Новое ценовое правило
+    back_to_price_books_list: Назад к ценовым правилам
+    back_to_currency_rates_list: Назад к курсам обмена
+    editing_currency_rate: Редактирование курса обмена
+    editing_price_book: Редактирование ценового правила

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -14,6 +14,7 @@ ru:
         default: По умолчанию
         priority: Приоритет
         role: Роль
+        role_id: Роль
         discount: Скидка?
         parent: Родительское ценовое правило
         price_adjustment_factor: Коэффициент корректировки цены

--- a/lib/spree_price_books.rb
+++ b/lib/spree_price_books.rb
@@ -1,4 +1,4 @@
 require 'spree_core'
-require 'money/bank/google_currency'
+require 'money/bank/open_exchange_rates_bank'
 require 'validates_timeliness'
 require 'spree_price_books/engine'

--- a/lib/tasks/price_books.rake
+++ b/lib/tasks/price_books.rake
@@ -6,19 +6,22 @@ namespace :price_books do
     # (optional)
     # set the seconds after than the current rates are automatically expired
     # by default, they never expire
-    Money::Bank::GoogleCurrency.ttl_in_seconds = 86400
-    # set default bank to instance of GoogleCurrency
-    Money.default_bank = Money::Bank::GoogleCurrency.new
-    Money::Currency.all.each do |currency|
-      # Limit to only major currencies, which have priority below 100.
-      next if currency.priority >= 100
+    oxr = Money::Bank::OpenExchangeRatesBank.new
+    oxr.app_id = Rails.application.config.openExchangeRate[:appId]
+    oxr.update_rates
+    oxr.cache = 'tmp/cache.json'
+    oxr.ttl_in_seconds = 86400
+    oxr.source = Spree::CurrencyRate.default.currency
+    Money.default_bank = oxr
+
+    Spree::Config[:supported_currencies].split(',').each do |currencyCode|
+      currency = Money::Currency.new(currencyCode)
       begin
-        rate = Money.default_bank.get_rate(Spree::CurrencyRate.default.currency, currency.iso_code)
+        rate = Money.default_bank.get_rate(Spree::CurrencyRate.default.currency, currency)
         if cr = Spree::CurrencyRate.find_or_create_by(base_currency: Spree::CurrencyRate.default.currency, currency: currency.iso_code, default: (Spree::Config[:currency] == currency.iso_code))
           cr.update_attribute :exchange_rate, rate
         end
-      rescue Money::Bank::UnknownRate # Google doesn't track this currency.
-      rescue Money::Bank::GoogleCurrencyFetchError => ex
+      rescue Exception => ex
         puts currency.inspect
         puts ex.message
         puts ex.backtrace

--- a/spree_price_books.gemspec
+++ b/spree_price_books.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_price_books'
-  s.version     = '2.3.0.beta'
+  s.version     = '3.1.0'
   s.summary     = 'Price books allowing flexible product pricing.'
   s.description = s.summary
   s.required_ruby_version = '>= 2.0.0'
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency 'google_currency'
-  s.add_dependency 'spree_core', '~> 2.3.0'
+  s.add_dependency 'spree_core', '~> 3.1.0'
   s.add_dependency 'validates_timeliness', '~> 3.0'
 
   s.add_development_dependency 'capybara', '~> 2.1'

--- a/spree_price_books.gemspec
+++ b/spree_price_books.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'google_currency'
+  s.add_dependency 'money-open-exchange-rates', '1.2.0'
   s.add_dependency 'spree_core', '~> 3.1.0'
   s.add_dependency 'validates_timeliness', '~> 3.0'
 


### PR DESCRIPTION
Since google currency is not working occasionally ([#65](https://github.com/RubyMoney/google_currency/issues/65)), it is suggested to change to [money-open-exchange-rates](https://github.com/spk/money-open-exchange-rates). 

As the repository is not active recently, I've modified it from the great work from (webgradus)[https://github.com/webgradus/spree_price_books] with the support of 3-1-stable so feel free to use the forked branch if anyone is wondering why the exchange rate could not be updated.